### PR TITLE
Fix dataset split selection for LoRA training

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ datasets from Hugging Face and combines them for training:
 - `avankumar/Battery_NER_70`
 - `batterydata/paper-abstracts`
 
+  *Note:* some versions of `batterydata/battery-device-data-qa` only provide a
+  `validation` split. The training script will automatically fall back to this
+  split if a `train` split is unavailable.
+
 The script loads `mradermacher/Llama3-KALE-LM-Chem-8B-GGUF` and applies a LoRA
 adapter using the [PEFT](https://github.com/huggingface/peft) library. Basic
 training hyperparameters such as batch size, learning rate and LoRA settings can

--- a/train_lora_peft.py
+++ b/train_lora_peft.py
@@ -5,7 +5,13 @@ from peft import LoraConfig, get_peft_model
 
 
 def load_and_prepare_datasets():
-    ds1 = load_dataset("batterydata/battery-device-data-qa", split="train")
+    ds1_dict = load_dataset("batterydata/battery-device-data-qa")
+    if "train" in ds1_dict:
+        ds1 = ds1_dict["train"]
+    else:
+        # some versions of the dataset only provide a validation split
+        ds1 = ds1_dict[list(ds1_dict.keys())[0]]
+
     ds2 = load_dataset("avankumar/Battery_NER_70", split="train")
     ds3 = load_dataset("batterydata/paper-abstracts", split="train")
 


### PR DESCRIPTION
## Summary
- handle the missing train split of `battery-device-data-qa`
- document the fallback to `validation` split in README

## Testing
- `python -m py_compile train_lora_peft.py`

------
https://chatgpt.com/codex/tasks/task_b_688a51a60c78832b98b6001957889e3b