### PR TITLE
Fix default model path for LoRA training

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ datasets from Hugging Face and combines them for training:
   `validation` split. The training script will automatically fall back to this
   split if a `train` split is unavailable.
 
-The script loads `mradermacher/Llama3-KALE-LM-Chem-8B-GGUF` and applies a LoRA
+The script loads `USTC-KnowledgeComputingLab/Llama3-KALE-LM-Chem-8B` and applies a LoRA
 adapter using the [PEFT](https://github.com/huggingface/peft) library. Basic
 training hyperparameters such as batch size, learning rate and LoRA settings can
 be configured via command line arguments. After training completes, the adapter

--- a/train_lora_peft.py
+++ b/train_lora_peft.py
@@ -81,7 +81,10 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", default="mradermacher/Llama3-KALE-LM-Chem-8B-GGUF")
+    parser.add_argument(
+        "--model_name",
+        default="USTC-KnowledgeComputingLab/Llama3-KALE-LM-Chem-8B",
+    )
     parser.add_argument("--output_dir", default="./lora_kale_lm_chem")
     parser.add_argument("--batch_size", type=int, default=2)
     parser.add_argument("--num_epochs", type=int, default=3)


### PR DESCRIPTION
## Summary
- update default `--model_name` in training script to use HF-format weights
- update README accordingly

## Testing
- `python -m py_compile train_lora_peft.py`

------
https://chatgpt.com/codex/tasks/task_b_688a52e417c4832bab15aff5ac116267