### PR TITLE
Fix fp16 training requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ training hyperparameters such as batch size, learning rate and LoRA settings can
 be configured via command line arguments. After training completes, the adapter
 weights are written to the directory specified by `--output_dir`.
 
+The script automatically disables fp16 mixed precision when no CUDA-capable GPU
+is detected, allowing CPU-only training environments to run without errors.
+
 Usage example:
 
 ```bash

--- a/train_lora_peft.py
+++ b/train_lora_peft.py
@@ -1,4 +1,5 @@
 import argparse
+import torch
 from datasets import load_dataset, concatenate_datasets
 from transformers import AutoTokenizer, AutoModelForCausalLM, DataCollatorForLanguageModeling, Trainer, TrainingArguments
 from peft import LoraConfig, get_peft_model
@@ -55,12 +56,15 @@ def main(args):
     )
     model = get_peft_model(model, lora_config)
 
+    use_fp16 = torch.cuda.is_available()
+    if not use_fp16:
+        print("GPU not found. Disabling fp16 training")
     training_args = TrainingArguments(
         output_dir=args.output_dir,
         per_device_train_batch_size=args.batch_size,
         num_train_epochs=args.num_epochs,
         learning_rate=args.lr,
-        fp16=True,
+        fp16=use_fp16,
         logging_steps=50,
         save_steps=200,
         save_total_limit=2,


### PR DESCRIPTION
## Summary
- make fp16 optional in `train_lora_peft.py` so the script works on CPU
- mention this behavior in the README

## Testing
- `python -m py_compile train_lora_peft.py`
- `pip install torch` *(fails: no internet)*

------
https://chatgpt.com/codex/tasks/task_b_688a55bf9dbc832baf02ca01d06a9148