### PR TITLE
Fix fp16 training requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ training hyperparameters such as batch size, learning rate and LoRA settings can
 be configured via command line arguments. After training completes, the adapter
 weights are written to the directory specified by `--output_dir`.
 
+The script automatically disables fp16 mixed precision when no CUDA-capable GPU
+is detected and loads the model directly on the CPU, allowing CPU-only training
+environments to run without errors.
+
 Usage example:
 
 ```bash

--- a/train_lora_peft.py
+++ b/train_lora_peft.py
@@ -1,4 +1,5 @@
 import argparse
+import torch
 from datasets import load_dataset, concatenate_datasets
 from transformers import AutoTokenizer, AutoModelForCausalLM, DataCollatorForLanguageModeling, Trainer, TrainingArguments
 from peft import LoraConfig, get_peft_model
@@ -43,7 +44,13 @@ def main(args):
     dataset = dataset.map(tokenize_fn, batched=True)
     dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
 
-    model = AutoModelForCausalLM.from_pretrained(args.model_name, torch_dtype="auto", device_map="auto")
+    if torch.cuda.is_available():
+        model = AutoModelForCausalLM.from_pretrained(
+            args.model_name, torch_dtype="auto", device_map="auto"
+        )
+    else:
+        # avoid meta tensor errors when loading on CPU-only setups
+        model = AutoModelForCausalLM.from_pretrained(args.model_name, torch_dtype="auto")
 
     lora_config = LoraConfig(
         r=args.lora_rank,
@@ -55,12 +62,15 @@ def main(args):
     )
     model = get_peft_model(model, lora_config)
 
+    use_fp16 = torch.cuda.is_available()
+    if not use_fp16:
+        print("GPU not found. Disabling fp16 training")
     training_args = TrainingArguments(
         output_dir=args.output_dir,
         per_device_train_batch_size=args.batch_size,
         num_train_epochs=args.num_epochs,
         learning_rate=args.lr,
-        fp16=True,
+        fp16=use_fp16,
         logging_steps=50,
         save_steps=200,
         save_total_limit=2,


### PR DESCRIPTION
## Summary
- make fp16 optional in `train_lora_peft.py` so the script works on CPU
- load the model on CPU when no GPU is found
- mention this CPU-friendly behavior in the README

## Testing
- `python -m py_compile train_lora_peft.py`
- `pip install torch` *(fails: no internet)*

------
https://chatgpt.com/codex/tasks/task_b_688a55bf9dbc832baf02ca01d06a9148