### PR TITLE
Add optional wandb logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Usage example:
 python train_lora_peft.py --output_dir ./adapter
 ```
 
+To log training metrics to [Weights & Biases](https://wandb.ai), specify a
+project name:
+
+```bash
+python train_lora_peft.py --output_dir ./adapter \
+  --wandb_project my-project --run_name lora-run
+```
+
 ## Cite Our Work
 
 ```text


### PR DESCRIPTION
## Summary
- add optional wandb integration to `train_lora_peft.py`
- document how to enable wandb logging

## Testing
- `python -m py_compile train_lora_peft.py`
- ⚠️ `pip install torch transformers datasets peft wandb --quiet` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_688ad2563bf4832baabe2b1db9e7b5a6